### PR TITLE
Remove ceres include

### DIFF
--- a/source/visualize.cpp
+++ b/source/visualize.cpp
@@ -23,7 +23,6 @@
 #include "ros/ros.h"
 #include <math.h>
 #include <rosbag/bag.h>
-#include <ceres/ceres.h>
 
 #include "ba.hpp"
 #include "tools.hpp"


### PR DESCRIPTION
It's not used from what I can see, and breaks the build if you don't have ceres installed.