### PR TITLE
Fix bug of reading "pose.json"

### DIFF
--- a/include/mypcl.hpp
+++ b/include/mypcl.hpp
@@ -56,9 +56,8 @@ namespace mypcl
     std::fstream file;
     file.open(filename);
     double tx, ty, tz, w, x, y, z;
-    while(!file.eof())
+    while(file >> tx >> ty >> tz >> w >> x >> y >> z)
     {
-      file >> tx >> ty >> tz >> w >> x >> y >> z;
       Eigen::Quaterniond q(w, x, y, z);
       Eigen::Vector3d t(tx, ty, tz);
       pose_vec.push_back(pose(qe * q, qe * t + te));


### PR DESCRIPTION
The function of reading _pose.json_ will return one more pose than the actual file contains.

This caused by _fstream::eof()_ in the while statement, which only returns false when your _fstream::get()_  fucntion return false. 

In the original code, it will always enter the code block once even your file has come to its end. So, it will append one more pose vector (which is identical to the last pose) every time.